### PR TITLE
Remove Permanent API key

### DIFF
--- a/.github/workflows/run-dev.yml
+++ b/.github/workflows/run-dev.yml
@@ -23,4 +23,4 @@ jobs:
         - name: Unarchive test files
           run: unzip one-of-each-type.zip
         - name: Run the test
-          run: python run_test.py dev "${{secrets.DEV_API_KEY}}" files/
+          run: python run_test.py dev files/

--- a/.github/workflows/run-prod.yml
+++ b/.github/workflows/run-prod.yml
@@ -23,4 +23,4 @@ jobs:
         - name: Unarchive test files
           run: unzip one-of-each-type.zip
         - name: Run the test
-          run: python run_test.py www "${{secrets.WWW_API_KEY}}" files/
+          run: python run_test.py www files/

--- a/.github/workflows/run-staging.yml
+++ b/.github/workflows/run-staging.yml
@@ -23,4 +23,4 @@ jobs:
         - name: Unarchive test files
           run: unzip one-of-each-type.zip
         - name: Run the test
-          run: python run_test.py staging "${{secrets.STAGING_API_KEY}}" files/
+          run: python run_test.py staging files/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 python run_test.py dev apiKey ../files/
 ```
 
-The first argument to the script should be the environment that the script should run on, the second should be the `apiKey` for that environment, and the third the directory containing files for upload.
+See `python run_test.py -h` for more information about the arguments it accepts.
 
 In Powershell, use .\venv\Scripts\activate instead of source venv/bin/activate
 

--- a/run_test.py
+++ b/run_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import logging
 import sys
 import os
@@ -236,17 +237,13 @@ def get_file_list(path):
     return file_list
 
 
-def main():
+def main(environment, api_key, path):
     global BASE_URL, API_KEY
-    if len(sys.argv) != 4:
-        logging.critical("This script requires 3 arguments: environment, api key, and "
-                         " a path to files to upload.")
+    if not os.path.isdir(path):
+        logging.critical("The path argument is not a directory")
         return
-    if not os.path.isdir(sys.argv[3]):
-        logging.critical("The 3rd argument is not a directory path")
-        return
-    BASE_URL = f"https://{sys.argv[1]}.permanent.org"
-    API_KEY = sys.argv[2]
+    BASE_URL = f"https://{environment}.permanent.org"
+    API_KEY = api_key
     email = "engineers+prmnttstr{}@permanent.org".format(int(time.time()))
     print("User account email:", email)
     password = "".join(random.choice(string.ascii_letters) for i in range(12))
@@ -261,7 +258,7 @@ def main():
     logged_in()
     parent_folder_id, parent_folder_link_id = get_folder_info()
 
-    files = get_file_list(sys.argv[3])
+    files = get_file_list(path)
     results = []
     headers = ["File Name", "Type", "Status", "File Formats", "Time"]
     for f in files:
@@ -271,5 +268,21 @@ def main():
     print(tabulate(results, headers, tablefmt="github"))
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Test that uploading to Permanent.org works correctly',
+    )
+    parser.add_argument('environment',
+        choices=['local', 'dev', 'staging', 'www'],
+        help='environment that the script should run on',
+    )
+    parser.add_argument('api_key', help='Permanent API key')
+    parser.add_argument('path',
+        help='directory containing files for upload',
+    )
+
+    return parser.parse_args()
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args.environment, args.api_key, args.path)

--- a/run_test.py
+++ b/run_test.py
@@ -12,7 +12,6 @@ import requests
 
 
 BASE_URL = ""
-API_KEY = ""
 
 class PermanentRequest():
     csrf = ""
@@ -25,7 +24,6 @@ class PermanentRequest():
         self.body = {
             "RequestVO": {
                 "data": data,
-                "apiKey": API_KEY,
                 "csrf": PermanentRequest.csrf
              },
         }
@@ -237,13 +235,12 @@ def get_file_list(path):
     return file_list
 
 
-def main(environment, api_key, path):
-    global BASE_URL, API_KEY
+def main(environment, path):
+    global BASE_URL
     if not os.path.isdir(path):
         logging.critical("The path argument is not a directory")
         return
     BASE_URL = f"https://{environment}.permanent.org"
-    API_KEY = api_key
     email = "engineers+prmnttstr{}@permanent.org".format(int(time.time()))
     print("User account email:", email)
     password = "".join(random.choice(string.ascii_letters) for i in range(12))
@@ -276,7 +273,6 @@ def parse_args():
         choices=['local', 'dev', 'staging', 'www'],
         help='environment that the script should run on',
     )
-    parser.add_argument('api_key', help='Permanent API key')
     parser.add_argument('path',
         help='directory containing files for upload',
     )
@@ -285,4 +281,4 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    main(args.environment, args.api_key, args.path)
+    main(args.environment, args.path)


### PR DESCRIPTION
The Permanent API no longer requires an API key. Remove it from the required arguments, and stop sending it in requests to the API.

But, before that, first replace the ad-hoc argument parsing code with the [argparse](https://docs.python.org/3/library/argparse.html) parser, which automatically handles missing required arguments and avoids magic numbers in referencing positional arguments. Also document/validate that the environment is one of the known environments; this is a little bit more rigid, but also makes it slightly less likely to accidentally misuse the tool.