### PR TITLE
Add always condition so that notify will run even in case of execute failure

### DIFF
--- a/.github/workflows/run-dev.yml
+++ b/.github/workflows/run-dev.yml
@@ -27,6 +27,7 @@ jobs:
         run: python -m permanent_upload dev files/
   notify:
     runs-on: ubuntu-latest
+    if: always()
     needs: execute
     steps:
       - name: Post a message in slack

--- a/.github/workflows/run-prod.yml
+++ b/.github/workflows/run-prod.yml
@@ -27,6 +27,7 @@ jobs:
         run: python -m permanent_upload www files/
   notify:
     runs-on: ubuntu-latest
+    if: always()
     needs: execute
     steps:
       - name: Post a message in slack

--- a/.github/workflows/run-staging.yml
+++ b/.github/workflows/run-staging.yml
@@ -27,6 +27,7 @@ jobs:
         run: python -m permanent_upload staging files/
   notify:
     runs-on: ubuntu-latest
+    if: always()
     needs: execute
     steps:
       - name: Post a message in slack


### PR DESCRIPTION
Context: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-not-requiring-dependent-jobs-to-be-successful