### PR TITLE
Fix #15, modify logic for slack notification

### DIFF
--- a/.github/workflows/run-dev.yml
+++ b/.github/workflows/run-dev.yml
@@ -29,7 +29,7 @@ jobs:
         run: python -m permanent_upload dev files/
   notify:
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository_dispatch && always() }}
+    if: always()
     needs: execute
     steps:
       - name: Post a message in slack

--- a/.github/workflows/run-dev.yml
+++ b/.github/workflows/run-dev.yml
@@ -29,7 +29,7 @@ jobs:
         run: python -m permanent_upload dev files/
   notify:
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ github.event_name == 'repository_dispatch' && always() }}
     needs: execute
     steps:
       - name: Post a message in slack


### PR DESCRIPTION
Since this test now runs on dev as part of the CI, we need this logic to only send notifications as part of the release. Looks like I bungled my first attempt. This should now work.