### PR TITLE
Upload test suite

### DIFF
--- a/js/.eslintrc.js
+++ b/js/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     "@typescript-eslint/no-unused-expressions": "off",
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-extraneous-class": "off",
+    "@typescript-eslint/no-use-before-define": "off",
     "cypress/no-async-tests": "off",
     "no-restricted-syntax": "off",
   },

--- a/js/.gitignore
+++ b/js/.gitignore
@@ -132,3 +132,7 @@ dist
 # Cypress
 cypress/videos
 cypress/screenshots
+cypress.env.json
+
+# Test files
+files/

--- a/js/README.md
+++ b/js/README.md
@@ -8,6 +8,21 @@ Currently it exists in a subdirectory since the plan is to eventually completely
 
 Run `npm install` to install dependencies.
 
+### Environment Files
+
+To set the preexisting account used for testing, copy the `cypress.env.json.template` file to `cypress.env.json` and fill in the account information.
+
+### Upload Test Files
+
+To run the upload test suite, you must fetch the test files from AWS. Using the AWS CLI credentials [used in the devenv,](https://github.com/PermanentOrg/devenv) Permanent engineers can fetch the proper testing files and move them into the `files` directory:
+
+```sh
+mkdir files
+aws s3 cp s3://permanent-repos/test_files/critical-path.zip .
+unzip critical-path.zip -d files
+rm critical-path.zip
+```
+
 ## Running Tests
 
 To run headless tests, simply run `npm start`.

--- a/js/cypress.config.ts
+++ b/js/cypress.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
       return conf;
     },
     video: false,
-    specPattern: ["cypress/e2e/health.cy.ts", "cypress/e2e/signup.cy.ts"],
     baseUrl: "https://ng.permanent.org:4200",
   },
 });

--- a/js/cypress.env.json.template
+++ b/js/cypress.env.json.template
@@ -1,0 +1,4 @@
+{
+  "accountEmail": [EXISTING ACCOUNT EMAIL HERE],
+  "accountPassword": [EXISTING ACCOUNT PASSWORD]
+}

--- a/js/cypress/e2e/signup.cy.ts
+++ b/js/cypress/e2e/signup.cy.ts
@@ -41,6 +41,7 @@ describe("signup spec", () => {
   });
   it("can log in to new account", () => {
     cy.login(signupEmail, signupPassword);
+    cy.visit("/app/private");
     cy.url().should("include", "private");
   });
   after(() => {

--- a/js/cypress/e2e/upload.cy.ts
+++ b/js/cypress/e2e/upload.cy.ts
@@ -1,0 +1,130 @@
+import Conversions from "../fixtures/expected-conversions.json";
+import TestFiles from "../fixtures/file-upload-data.json";
+
+interface TestFile {
+  filename: string;
+  extension: string;
+  type: string;
+}
+
+interface ExpectedConversion {
+  type: string;
+  extension: string;
+  convertTime?: number;
+}
+
+const conversions: ExpectedConversion[] = Conversions as ExpectedConversion[];
+const testFiles: TestFile[] = TestFiles as TestFile[];
+const defaultConversionTime = 25000;
+
+before(() => {
+  loginWithAccount();
+  cy.intercept("POST", "api/folder/navigateMin").as("navigate");
+  cy.visit("/app/private");
+  cy.wait("@navigate");
+  cy.wait("@navigate");
+  cy.window().then((windowObj) => {
+    if (windowObj.document.querySelectorAll("pr-file-list-item").length > 0) {
+      deleteFiles();
+    }
+  });
+});
+
+describe("upload spec", () => {
+  beforeEach(() => {
+    loginWithAccount();
+  });
+  after(() => {
+    deleteFiles();
+  });
+
+  testFiles.forEach((file: TestFile) => {
+    it(`can upload: ${file.extension}`, () => {
+      testUploadFileAndConversion(file);
+    });
+  });
+
+  function testUploadFileAndConversion(file: TestFile): void {
+    uploadFile(file.filename, file.extension);
+    waitForUploadAndConversion(getExpectedConversionTime(file));
+    expectFileIsInFileList(file.filename);
+    expectConversionToFormat(
+      file.filename,
+      file.extension,
+      getExpectedConversionExtension(file),
+    );
+    disambiguateFilename(file.filename, file.extension);
+  }
+  function uploadFile(filename: string, extension: string): void {
+    cy.get("pr-upload-button.full-width input").selectFile(
+      `files/${filename}.${extension}`,
+      { force: true },
+    );
+  }
+  function waitForUploadAndConversion(expectedConversionTime: number): void {
+    cy.wait("@getLeanItems", {
+      timeout: 30000,
+    }).then(() => {
+      // Processing is completely opaque to the web-app, so we just have to sleep for an arbitrary time
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(expectedConversionTime);
+    });
+  }
+  function expectFileIsInFileList(filename: string): void {
+    cy.get("pr-file-list-item").contains(filename).should("exist");
+  }
+  function expectConversionToFormat(
+    filename: string,
+    extension: string,
+    conversionExtension: string,
+  ): void {
+    cy.get("pr-file-list-item").contains(filename).click();
+    cy.get("label")
+      .contains("Original Format")
+      .siblings()
+      .should("contain.text", extension);
+    cy.get("label")
+      .contains("Permanent Format")
+      .siblings()
+      .should("contain.text", conversionExtension);
+  }
+  function disambiguateFilename(filename: string, extension: string): void {
+    cy.intercept("POST", "/api/record/update").as("updateRecord");
+    cy.get("label")
+      .contains("Name")
+      .siblings()
+      .filter("pr-inline-value-edit")
+      .click();
+    cy.get("input[name='text']").clear();
+    cy.get("input[name='text']").type(`[PASSED] ${extension}: ${filename}`);
+    cy.get("button[name='save']").click();
+    cy.wait("@updateRecord");
+  }
+  function getExpectedConversionTime(file: TestFile): number {
+    return (
+      conversions.find((obj: ExpectedConversion) => obj.type === file.type)
+        ?.convertTime ?? defaultConversionTime
+    );
+  }
+  function getExpectedConversionExtension(file: TestFile): string {
+    return (
+      conversions.find((obj: ExpectedConversion) => obj.type === file.type)
+        ?.extension ?? file.type
+    );
+  }
+});
+
+function loginWithAccount(): void {
+  cy.intercept("POST", "api/folder/getLeanItems").as("getLeanItems");
+  const email = `${Cypress.env("accountEmail")}`;
+  const password = `${Cypress.env("accountPassword")}`;
+  cy.login(email, password);
+  cy.visit("/app/private");
+}
+
+function deleteFiles(): void {
+  cy.get("pr-file-list-item").first().click();
+  cy.get("pr-file-list-item").last().click({ shiftKey: true });
+  cy.get("span").contains("Delete").parent().click();
+  cy.get("pr-prompt .btn-primary").click();
+}

--- a/js/cypress/fixtures/expected-conversions.json
+++ b/js/cypress/fixtures/expected-conversions.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "document",
+    "extension": "odt"
+  },
+  {
+    "type": "video",
+    "extension": "mp4"
+  },
+  {
+    "type": "image",
+    "extension": "jpg"
+  },
+  {
+    "type": "presentation",
+    "extension": "odp"
+  },
+  {
+    "type": "spreadsheet",
+    "extension": "ods"
+  },
+  {
+    "type": "audio",
+    "extension": "mp3",
+    "convertTime": 45000
+  }
+]

--- a/js/cypress/fixtures/file-upload-data.json
+++ b/js/cypress/fixtures/file-upload-data.json
@@ -1,0 +1,42 @@
+[
+  {
+    "filename": "DOCX 2018-10-05 Permanent Legacy Foundation Manifesto",
+    "extension": "docx",
+    "type": "document"
+  },
+  {
+    "filename": "Meet Terry",
+    "extension": "mov",
+    "type": "video"
+  },
+  {
+    "filename": "Permanent Team at 2020 RootsTech Conference",
+    "extension": "heic",
+    "type": "image"
+  },
+  {
+    "filename": "Permanent Team at 2020 RootsTech Conference",
+    "extension": "tiff",
+    "type": "image"
+  },
+  {
+    "filename": "PPTX 2020-08-05 Permanent Legacy Foundation Overview Deck",
+    "extension": "pptx",
+    "type": "presentation"
+  },
+  {
+    "filename": "This Land Is Your Land",
+    "extension": "wav",
+    "type": "audio"
+  },
+  {
+    "filename": "XLSX 2020 Q4 Objectives and Key Results",
+    "extension": "xlsx",
+    "type": "spreadsheet"
+  },
+  {
+    "filename": "ZIP 2018-10-05 Permanent Legacy Foundation Manifesto",
+    "extension": "zip",
+    "type": "zip"
+  }
+]

--- a/js/cypress/support/commands.ts
+++ b/js/cypress/support/commands.ts
@@ -7,11 +7,14 @@ declare global {
 }
 
 Cypress.Commands.add("login", (email: string, password: string) => {
-  cy.visit(`/app/auth`);
-  cy.get('input[name="email"]').type(email);
-  cy.get('input[name="password"]').type(password);
-  cy.get("#rememberMe").uncheck();
-  cy.get('button[type="submit"]').click();
+  cy.session([email, password], () => {
+    cy.visit(`/app/auth`);
+    cy.get('input[name="email"]').type(email);
+    cy.get('input[name="password"]').type(password);
+    cy.get("#rememberMe").uncheck();
+    cy.get('button[type="submit"]').click();
+    cy.location("pathname").should("include", "/app/private");
+  });
 });
 
 // We need an import or export for TypeScript to recognize this file as a module

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -4,7 +4,8 @@
     "ignoreDeprecations": "5.0",
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "resolveJsonModule": true
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
This PR adds the file upload test suite to the Typescript functional test.

**Open Questions**
- Currently this test suite waits an arbitrary amount of time before verifying conversion status. Should the tests poll instead? Probably (this is why this is still a draft).
- Why should we have to go through AWS to get the test files? The Python functional test does this... but wouldn't it make more sense to keep these assets in the repository instead? The only issue is that I think at least one of the test files contains copyrighted content (the wav file specifically). Could we replace that with something in the public domain (or even just a generated sine wave file instead) to have all the files inside of the repository?
- While we used the API directly to do cleanup work in the signup test suite, I found it much simpler just to do cleanup through the UI when it comes to deleting files. Is this an issue?

**Testing Instructions:**
1. Create a testing account on the environment you will be running these tests on.
2. View the README.md file to see new setup instructions, including how to set environment variables and how to download the testing files.
3. Run the tests
    - Specifically, the upload test suite should probably be run in isolation since the signup test is outdated with new onboarding being live now. 