### PR TITLE
Create test archive in a separate call from account creation

### DIFF
--- a/permanent_upload/__main__.py
+++ b/permanent_upload/__main__.py
@@ -51,6 +51,7 @@ def main(environment, path):
 
     api = PermanentAPI(f"https://{environment}.permanent.org")
     createaccount_result = api.create_account(email, password)
+    api.create_archive("Functional Filetype Test", "type.archive.person")
     login_result = api.login(email, password)
     archive = login_result.response["ArchiveVO"]
     api.get_archive(archive["archiveId"], archive["archiveNbr"])

--- a/permanent_upload/permanent.py
+++ b/permanent_upload/permanent.py
@@ -154,9 +154,25 @@ class PermanentAPI:
                     "password": password,
                     "passwordVerify": password,
                 },
+                "SimpleVO": {
+                    "key": "createArchive",
+                    "value": False,
+                },
             }
         ]
         return PermanentRequest(self.base_url, "/api/account/post", data=body)
+
+    def create_archive(self, name, archive_type):
+        logging.info("Create archive - Name: %s, Type: %s", name, archive_type)
+        body = [
+            {
+                "ArchiveVO": {
+                    "fullName": name,
+                    "type": archive_type,
+                }
+            }
+        ]
+        return PermanentRequest(self.base_url, "/api/archive/post", data=body)
 
     def login(self, email, password):
         logging.info("Login as %s", email)


### PR DESCRIPTION
We are deprecating the ability to create an archive as part of the same API call that creates an account. Thus, this commit updates these tests to stop using that feature.