### PR TITLE
Stop failing because of archivematica access copies

### DIFF
--- a/permanent_upload/validation.py
+++ b/permanent_upload/validation.py
@@ -22,4 +22,4 @@ def validate_supported_types(results, data_file="data/supported_file_types.csv")
         )
         if result[2] == "ok":
             # File conversions (e.g. html,pdfa,txt)
-            assert result[3] == validation_dataset[extension]["conversions"]
+            assert set(result[3]) >= set(validation_dataset[extension]["conversions"])


### PR DESCRIPTION
Presently, the functional tests are sometimes failing because Archivematica creates an "access copy" (which is really just the original) in an unknown format. This happens because Archivematica isn't presently configured to generate proper access copies of Office files. For the moment, we should ignore these files, as the don't represent an actual failure.