### PR TITLE
Only run dev workflow on push to main

### DIFF
--- a/.github/workflows/run-dev.yml
+++ b/.github/workflows/run-dev.yml
@@ -4,6 +4,8 @@ on:
   repository_dispatch:
     types: [dev_deployed]
   push:
+    branches:
+      - main
 
 
 jobs:


### PR DESCRIPTION
This was failing on dependabot PRs because they don't have access to secrets.