### PR TITLE
Allow manual functional test run

### DIFF
--- a/.github/workflows/run-dev.yml
+++ b/.github/workflows/run-dev.yml
@@ -1,10 +1,10 @@
 name: Run shortlist (dev)
 
 on:
+  workflow_displatch:
   repository_dispatch:
     types: [dev_deployed]
   push:
-
 
 jobs:
   execute:


### PR DESCRIPTION
Dependabot can't run this flow without access to more secrets (our entire AWS config), which I am not inclined to give it. Dependabots are rare enough on this repo that I think it's fine to require a manual check.

Let me know what you think though!